### PR TITLE
Added sublime-project and sublime-workspace file types to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 node_modules
 bower_components
 *.css.map
+*.sublime-project
+*.sublime-workspace


### PR DESCRIPTION
Adding Sublime text editor *.sublime-workspace and *.sublime-project file types to .gitignore.
